### PR TITLE
Add a skeleton structure for the Japanese translation

### DIFF
--- a/_includes/foot.html
+++ b/_includes/foot.html
@@ -1,5 +1,6 @@
 <footer class="foot wrap">
     <hr/>
+    <p>Translations: <a href="{{ site.url }}">English</a> &middot; <a href="{{ site.url}}/jp">日本語</a></p>
     <p>
         This guide is being discussed on Hacker News [
             <a href="https://news.ycombinator.com/item?id=9941150">1</a>,

--- a/_includes/sqlstyle.guide.jp.md
+++ b/_includes/sqlstyle.guide.jp.md
@@ -1,0 +1,3 @@
+# SQL style guide - Japanese translation
+
+...content goes here...

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
         <title property="og:title">{{ site.name }}</title>
         <link href="http://fonts.googleapis.com/css?family=PT+Sans|Roboto+Slab|Droid+Sans+Mono" rel="stylesheet" type="text/css">
-        <link rel="stylesheet" href="style.css">
+        <link rel="stylesheet" href="{{ site.url }}/style.css">
 
         <meta content="website" property="og:type">
         <meta content="{{ site.url }}" property="og:url">

--- a/jp/index.md
+++ b/jp/index.md
@@ -1,0 +1,8 @@
+---
+layout: default
+---
+
+* TOC
+{:toc}
+
+{% include sqlstyle.guide.jp.md %}


### PR DESCRIPTION
This sets a basic structure for the Japanese translation of the guide. To access this branch, fork the repository, use git to clone the repository. Then run `git checkout japanese`.

You should only have to update the _includes/sqlstyle.guide.jp.md file and everything else should just work.

For testing you can setup Jekyll locally by running `gem install jekyll bundler` in a terminal and then from the root directory run `bundle exec jekyll serve`. Visiting http://127.0.0.1:4040 in your web browser should now show the site. The Japanese translation will be available at http://127.0.0.1:4040/jp

Hope that helps to get you going.

Thanks,
Simon